### PR TITLE
[FEAT] Implement Voting System

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,8 @@ import { Delegate } from './Delegate'
 import { Election } from './Election'
 import { History } from './History'
 import { Vote } from './Vote'
+import { VoteQueueProvider } from './VoteQueueContext'
+import { VoteQueuePanel } from './VoteQueuePanel'
 import { useEffect, useState } from 'react'
 import { invoke } from '@tauri-apps/api/core'
 
@@ -24,27 +26,28 @@ function App() {
   const hasElection = election != undefined && election.id != ""
 
   return (
-    <>
-    <nav className='fixed top-0 left-0 w-full z-50 flex items-center justify-between px-8 py-2 bg-gray-800 text-white'>
-      <a href='/home'>Election</a>
-      {hasElection && <a href='/overview'>Overview</a>}
-      {hasElection && <a href='/history'>History</a>}
-      {hasElection && <a href='/vote'>Vote</a>}
-      {hasElection && <a href='/delegate'>Delegate</a>}
-    </nav>
-    <Router>
-      <div className='pt-16 mx-auto flex flex-col min-h-screen'>
-        <Routes>
-          <Route path='/' element={<Navigate to='/home' />} />
-          <Route path='/home' element={<Election />} />
-          <Route path='/overview' element={<Overview election={election!}/>} />
-          <Route path='/history' element={<History election={election!} />} />
-          <Route path='/vote' element={<Vote election={election!} />} />
-          <Route path='/delegate' element={<Delegate election={election!} />} />
-        </Routes>
-      </div>
-    </Router>
-    </>
+    <VoteQueueProvider>
+      <nav className='fixed top-0 left-0 w-full z-50 flex items-center justify-between px-8 py-2 bg-gray-800 text-white'>
+        <a href='/home'>Election</a>
+        {hasElection && <a href='/overview'>Overview</a>}
+        {hasElection && <a href='/history'>History</a>}
+        {hasElection && <a href='/vote'>Vote</a>}
+        {hasElection && <a href='/delegate'>Delegate</a>}
+      </nav>
+      <Router>
+        <div className='pt-16 mx-auto flex flex-col min-h-screen'>
+          <Routes>
+            <Route path='/' element={<Navigate to='/home' />} />
+            <Route path='/home' element={<Election />} />
+            <Route path='/overview' element={<Overview election={election!}/>} />
+            <Route path='/history' element={<History election={election!} />} />
+            <Route path='/vote' element={<Vote election={election!} />} />
+            <Route path='/delegate' element={<Delegate election={election!} />} />
+          </Routes>
+        </div>
+      </Router>
+      <VoteQueuePanel />
+    </VoteQueueProvider>
   )
 }
 

--- a/src/Delegate.tsx
+++ b/src/Delegate.tsx
@@ -1,8 +1,8 @@
-import { Channel, invoke } from "@tauri-apps/api/core";
+import { invoke } from "@tauri-apps/api/core";
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { SetElectionMessage } from "./SetElectionMessage";
-import Swal from "sweetalert2";
+import { useVoteQueue } from "./VoteQueueContext";
 import {
   Card,
   CardContent,
@@ -11,7 +11,6 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
-import { Spinner } from "./Spinner";
 import {
   Form,
   FormControl,
@@ -23,7 +22,6 @@ import {
 import { Button } from "./components/ui/button";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useNavigate } from "react-router-dom";
 
 const voteSchema = z.object({
   address: z.string(),
@@ -31,10 +29,8 @@ const voteSchema = z.object({
 });
 
 export const Delegate: React.FC<ElectionProps> = ({ election }) => {
-  const navigate = useNavigate();
+  const { addJob } = useVoteQueue();
   const [address, setAddress] = useState<string | undefined>();
-  const [voting, setVoting] = useState(false);
-  const [message, setMessage] = useState<string>("");
 
   useEffect(() => {
     (async () => {
@@ -53,31 +49,13 @@ export const Delegate: React.FC<ElectionProps> = ({ election }) => {
   const { control, handleSubmit } = form;
 
   const onSubmit = (delegation: Vote) => {
-    setVoting(true);
-    (async () => {
-      try {
-        delegation.amount = Math.floor(delegation.amount * 100000);
-        const channel = new Channel<string>();
-        channel.onmessage = (m) => {
-          setMessage(m);
-        };
-        const hash: string = await invoke("vote", {channel: channel, ...delegation});
-        await Swal.fire({
-          icon: "success",
-          title: hash,
-        });
-        navigate("/overview");
-      } catch (e: any) {
-        console.log(e);
-        await Swal.fire({
-          icon: "error",
-          title: e,
-        });
-      } finally {
-        setVoting(false);
-      }
-      await invoke("sync");
-    })();
+    addJob({
+      type: "delegate",
+      address: delegation.address,
+      candidateName: delegation.address.slice(0, 16) + "...",
+      amount: delegation.amount,
+    });
+    form.reset();
   };
 
   if (election == undefined || election.id == "") return <SetElectionMessage />;
@@ -138,17 +116,11 @@ export const Delegate: React.FC<ElectionProps> = ({ election }) => {
               />
             </CardContent>
             <CardFooter>
-              <Button type="submit">Delegate</Button>
+              <Button type="submit">Queue Delegation</Button>
             </CardFooter>
           </Card>
         </form>
       </Form>
-      {voting && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-        <div>{message}&nbsp;</div>
-        <Spinner />
-      </div>
-    )}
     </div>
   );
 };

--- a/src/Vote.tsx
+++ b/src/Vote.tsx
@@ -1,9 +1,7 @@
-import { Channel, invoke } from "@tauri-apps/api/core";
 import { SetElectionMessage } from "./SetElectionMessage";
 import { SubmitHandler, useForm } from "react-hook-form";
 import { useState } from "react";
-import Swal from "sweetalert2";
-import { Spinner } from "./Spinner";
+import { useVoteQueue } from "./VoteQueueContext";
 import {
   Card,
   CardDescription,
@@ -18,12 +16,20 @@ import {
   FormLabel,
   FormMessage,
 } from "./components/ui/form";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "./components/ui/dialog";
 import { Button } from "./components/ui/button";
 import { Input } from "./components/ui/input";
 import { RadioGroup, RadioGroupItem } from "./components/ui/radio-group";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useNavigate } from "react-router-dom";
 
 const voteSchema = z.object({
   address: z.string().min(1, "A choice is required"),
@@ -31,44 +37,108 @@ const voteSchema = z.object({
 });
 
 export const Vote: React.FC<ElectionProps> = ({ election }) => {
-  const navigate = useNavigate();
-  const [busy, setBusy] = useState(false);
-  const [message, setMessage] = useState("");
+  const { addJob } = useVoteQueue();
+  const [jsonText, setJsonText] = useState("");
+  const [jsonError, setJsonError] = useState("");
+  const [jsonDialogOpen, setJsonDialogOpen] = useState(false);
+  const [formKey, setFormKey] = useState(0);
 
   const form = useForm<z.infer<typeof voteSchema>>({
     resolver: zodResolver(voteSchema),
-    defaultValues: {
-      address: "",
-      amount: 0,
-    },
+    defaultValues: { address: "", amount: 0 },
   });
   const { control, handleSubmit } = form;
 
   const onSubmit: SubmitHandler<Vote> = (vote) => {
-    setBusy(true);
-    (async () => {
-      try {
-        vote.amount = Math.floor(vote.amount * 100000);
-        const voteChannel = new Channel<string>();
-        voteChannel.onmessage = (m) => {
-          setMessage(m);
-        };
-        const hash: string = await invoke("vote", { channel: voteChannel, ...vote });
-        await Swal.fire({
-          icon: "success",
-          title: hash,
-        });
-        navigate("/overview");
-      } catch (e: any) {
-        console.log(e);
-        await Swal.fire({
-          icon: "error",
-          title: e,
-        });
-      } finally {
-        setBusy(false);
+    const candidate = election.candidates.find(
+      (c) => c.address === vote.address
+    );
+    addJob({
+      type: "vote",
+      address: vote.address,
+      candidateName: candidate?.choice ?? vote.address.slice(0, 16),
+      amount: vote.amount,
+    });
+    form.reset();
+    setFormKey((k) => k + 1);
+  };
+
+  const resolveAddress = (
+    v: { address?: string; choice?: string },
+    index: number
+  ): { address: string; name: string } | string => {
+    if (v.address) {
+      const candidate = election.candidates.find(
+        (c) => c.address === v.address
+      );
+      if (!candidate) return `Vote ${index + 1}: unknown address`;
+      return { address: v.address, name: candidate.choice };
+    }
+    if (v.choice) {
+      const candidate = election.candidates.find(
+        (c) => c.choice.toLowerCase() === v.choice!.toLowerCase()
+      );
+      if (!candidate) return `Vote ${index + 1}: unknown choice "${v.choice}"`;
+      return { address: candidate.address, name: candidate.choice };
+    }
+    return `Vote ${index + 1}: must provide "address" or "choice"`;
+  };
+
+  const handleJsonImport = () => {
+    setJsonError("");
+    try {
+      const parsed = JSON.parse(jsonText);
+      const votes: { address?: string; choice?: string; amount: number }[] =
+        Array.isArray(parsed) ? parsed : parsed.votes;
+
+      if (!Array.isArray(votes)) {
+        setJsonError('Expected an array or an object with a "votes" array');
+        return;
       }
-    })();
+
+      const errors: string[] = [];
+      const resolved: { address: string; name: string; amount: number }[] = [];
+
+      votes.forEach((v, i) => {
+        if (!v.amount || v.amount <= 0) {
+          errors.push(`Vote ${i + 1}: invalid amount`);
+          return;
+        }
+        const result = resolveAddress(v, i);
+        if (typeof result === "string") {
+          errors.push(result);
+        } else {
+          resolved.push({ ...result, amount: v.amount });
+        }
+      });
+
+      if (errors.length > 0) {
+        setJsonError(errors.join("\n"));
+        return;
+      }
+
+      for (const v of resolved) {
+        addJob({
+          type: "vote",
+          address: v.address,
+          candidateName: v.name,
+          amount: v.amount,
+        });
+      }
+
+      setJsonText("");
+      setJsonDialogOpen(false);
+    } catch {
+      setJsonError("Invalid JSON");
+    }
+  };
+
+  const generateTemplate = () => {
+    const template = election.candidates.map((c) => ({
+      choice: c.choice,
+      amount: 0,
+    }));
+    setJsonText(JSON.stringify(template, null, 2));
   };
 
   if (election == undefined || election.id == "") return <SetElectionMessage />;
@@ -77,11 +147,62 @@ export const Vote: React.FC<ElectionProps> = ({ election }) => {
     <div className="flex flex-col justify-center items-center">
       <Card className="w-md p-2">
         <CardHeader>
-          <CardTitle>Vote</CardTitle>
-          <CardDescription>{election.question}</CardDescription>
+          <div className="flex items-center justify-between">
+            <div>
+              <CardTitle>Vote</CardTitle>
+              <CardDescription>{election.question}</CardDescription>
+            </div>
+            <Dialog open={jsonDialogOpen} onOpenChange={setJsonDialogOpen}>
+              <DialogTrigger asChild>
+                <Button variant="outline" size="sm">
+                  Batch Import
+                </Button>
+              </DialogTrigger>
+              <DialogContent>
+                <DialogHeader>
+                  <DialogTitle>Batch Vote Import</DialogTitle>
+                  <DialogDescription>
+                    Paste JSON to queue multiple votes. Use choice names or
+                    addresses.
+                  </DialogDescription>
+                </DialogHeader>
+                <div className="flex gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={generateTemplate}
+                  >
+                    Generate Template
+                  </Button>
+                </div>
+                <textarea
+                  className="w-full h-40 font-mono text-sm border rounded p-2 resize-none"
+                  placeholder={
+                    '[\n  { "choice": "Option A", "amount": 5 },\n  { "choice": "Option B", "amount": 3 }\n]'
+                  }
+                  value={jsonText}
+                  onChange={(e) => setJsonText(e.target.value)}
+                />
+                {jsonError && (
+                  <pre className="text-red-500 text-xs whitespace-pre-wrap">
+                    {jsonError}
+                  </pre>
+                )}
+                <DialogFooter>
+                  <Button onClick={handleJsonImport} disabled={!jsonText.trim()}>
+                    Queue All Votes
+                  </Button>
+                </DialogFooter>
+              </DialogContent>
+            </Dialog>
+          </div>
         </CardHeader>
         <Form {...form}>
-          <form className="flex bg-gray-100" onSubmit={handleSubmit(onSubmit)}>
+          <form
+            key={formKey}
+            className="flex bg-gray-100"
+            onSubmit={handleSubmit(onSubmit)}
+          >
             <div className="flex flex-col gap-4">
               <FormField
                 control={control}
@@ -134,17 +255,11 @@ export const Vote: React.FC<ElectionProps> = ({ election }) => {
                 )}
               />
 
-              <Button type="submit">Vote</Button>
+              <Button type="submit">Queue Vote</Button>
             </div>
           </form>
         </Form>
       </Card>
-      {busy && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-          <div>{message}&nbsp;</div>
-        <Spinner />
-      </div>
-    )}
     </div>
   );
 };

--- a/src/VoteQueueContext.tsx
+++ b/src/VoteQueueContext.tsx
@@ -1,0 +1,177 @@
+import { Channel, invoke } from "@tauri-apps/api/core";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useRef,
+  useState,
+} from "react";
+
+export type VoteJobStatus = "queued" | "sending" | "sent" | "failed";
+
+export type VoteJob = {
+  id: string;
+  type: "vote" | "delegate";
+  address: string;
+  candidateName: string;
+  amount: number;
+  status: VoteJobStatus;
+  message: string;
+  hash?: string;
+  error?: string;
+};
+
+type VoteQueueContextType = {
+  jobs: VoteJob[];
+  addJob: (
+    job: Pick<VoteJob, "type" | "address" | "candidateName" | "amount">
+  ) => void;
+  retryJob: (id: string) => void;
+  removeJob: (id: string) => void;
+  clearCompleted: () => void;
+};
+
+const VoteQueueContext = createContext<VoteQueueContextType | null>(null);
+
+export function useVoteQueue() {
+  const ctx = useContext(VoteQueueContext);
+  if (!ctx)
+    throw new Error("useVoteQueue must be used within VoteQueueProvider");
+  return ctx;
+}
+
+let nextId = 0;
+
+export function VoteQueueProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [jobs, setJobs] = useState<VoteJob[]>([]);
+  const processingRef = useRef(false);
+  const jobsRef = useRef(jobs);
+  jobsRef.current = jobs;
+
+  const processNext = useCallback(async () => {
+    if (processingRef.current) return;
+
+    const next = jobsRef.current.find((j) => j.status === "queued");
+    if (!next) return;
+
+    processingRef.current = true;
+
+    setJobs((prev) =>
+      prev.map((j) =>
+        j.id === next.id
+          ? { ...j, status: "sending" as const, message: "Preparing..." }
+          : j
+      )
+    );
+
+    try {
+      const voteAmount = Math.floor(next.amount * 100000);
+      const channel = new Channel<string>();
+      channel.onmessage = (m) => {
+        setJobs((prev) =>
+          prev.map((j) => (j.id === next.id ? { ...j, message: m } : j))
+        );
+      };
+
+      const hash: string = await invoke("vote", {
+        channel,
+        address: next.address,
+        amount: voteAmount,
+      });
+
+      if (next.type === "delegate") {
+        setJobs((prev) =>
+          prev.map((j) =>
+            j.id === next.id ? { ...j, message: "Syncing ballots..." } : j
+          )
+        );
+        try {
+          const syncChannel = new Channel<string>();
+          syncChannel.onmessage = () => {};
+          await invoke("sync", { channel: syncChannel });
+        } catch {
+          // sync failure is non-critical
+        }
+      }
+
+      setJobs((prev) =>
+        prev.map((j) =>
+          j.id === next.id
+            ? {
+                ...j,
+                status: "sent" as const,
+                hash,
+                message: "Complete",
+              }
+            : j
+        )
+      );
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      setJobs((prev) =>
+        prev.map((j) =>
+          j.id === next.id
+            ? { ...j, status: "failed" as const, error: msg, message: msg }
+            : j
+        )
+      );
+    } finally {
+      processingRef.current = false;
+      setTimeout(() => processNext(), 0);
+    }
+  }, []);
+
+  const addJob = useCallback(
+    (job: Pick<VoteJob, "type" | "address" | "candidateName" | "amount">) => {
+      const newJob: VoteJob = {
+        ...job,
+        id: String(++nextId),
+        status: "queued",
+        message: "Queued",
+      };
+      setJobs((prev) => [...prev, newJob]);
+      setTimeout(() => processNext(), 0);
+    },
+    [processNext]
+  );
+
+  const retryJob = useCallback(
+    (id: string) => {
+      setJobs((prev) =>
+        prev.map((j) =>
+          j.id === id && j.status === "failed"
+            ? {
+                ...j,
+                status: "queued" as const,
+                message: "Queued",
+                error: undefined,
+              }
+            : j
+        )
+      );
+      setTimeout(() => processNext(), 0);
+    },
+    [processNext]
+  );
+
+  const removeJob = useCallback((id: string) => {
+    setJobs((prev) => prev.filter((j) => j.id !== id));
+  }, []);
+
+  const clearCompleted = useCallback(() => {
+    setJobs((prev) => prev.filter((j) => j.status !== "sent"));
+  }, []);
+
+  return (
+    <VoteQueueContext.Provider
+      value={{ jobs, addJob, retryJob, removeJob, clearCompleted }}
+    >
+      {children}
+    </VoteQueueContext.Provider>
+  );
+}
+

--- a/src/VoteQueuePanel.tsx
+++ b/src/VoteQueuePanel.tsx
@@ -1,0 +1,154 @@
+import { useState } from "react";
+import { useVoteQueue, VoteJob } from "./VoteQueueContext";
+import { Spinner } from "./Spinner";
+import { Button } from "./components/ui/button";
+import { Progress } from "./components/ui/progress";
+
+function estimateProgress(message: string): number {
+  const lower = message.toLowerCase();
+  if (lower.includes("complete")) return 100;
+  if (lower.includes("broadcast") || lower.includes("send")) return 95;
+  if (lower.includes("transaction") || lower.includes("tx")) return 80;
+  if (lower.includes("proof") || lower.includes("prov")) return 60;
+  if (lower.includes("nullifier") || lower.includes("tree")) return 40;
+  if (lower.includes("witness")) return 25;
+  if (lower.includes("prepar")) return 10;
+  return 5;
+}
+
+function StatusIcon({ status }: { status: VoteJob["status"] }) {
+  switch (status) {
+    case "queued":
+      return (
+        <span className="inline-block w-4 h-4 text-center text-gray-400 leading-4">
+          ○
+        </span>
+      );
+    case "sending":
+      return <Spinner className="h-4 w-4" />;
+    case "sent":
+      return (
+        <span className="inline-block w-4 h-4 text-center text-green-500 leading-4">
+          ✓
+        </span>
+      );
+    case "failed":
+      return (
+        <span className="inline-block w-4 h-4 text-center text-red-500 leading-4">
+          ✗
+        </span>
+      );
+  }
+}
+
+export function VoteQueuePanel() {
+  const { jobs, retryJob, removeJob, clearCompleted } = useVoteQueue();
+  const [collapsed, setCollapsed] = useState(false);
+
+  if (jobs.length === 0) return null;
+
+  const sending = jobs.filter((j) => j.status === "sending").length;
+  const queued = jobs.filter((j) => j.status === "queued").length;
+  const sent = jobs.filter((j) => j.status === "sent").length;
+  const failed = jobs.filter((j) => j.status === "failed").length;
+
+  const currentJob = jobs.find((j) => j.status === "sending");
+  const progress = currentJob ? estimateProgress(currentJob.message) : 0;
+
+  return (
+    <div className="fixed bottom-4 right-4 z-50 w-80 bg-white border rounded-lg shadow-lg overflow-hidden">
+      {/* Header */}
+      <div
+        className="flex items-center justify-between px-3 py-2 bg-gray-800 text-white cursor-pointer select-none"
+        onClick={() => setCollapsed(!collapsed)}
+      >
+        <div className="flex items-center gap-2 text-sm font-medium">
+          Vote Queue
+          {sending > 0 && <Spinner className="h-3 w-3" />}
+        </div>
+        <div className="flex items-center gap-1.5 text-xs">
+          {queued > 0 && (
+            <span className="bg-gray-500 px-1.5 py-0.5 rounded">
+              {queued}
+            </span>
+          )}
+          {sending > 0 && (
+            <span className="bg-blue-500 px-1.5 py-0.5 rounded">
+              {sending}
+            </span>
+          )}
+          {sent > 0 && (
+            <span className="bg-green-600 px-1.5 py-0.5 rounded">{sent}</span>
+          )}
+          {failed > 0 && (
+            <span className="bg-red-600 px-1.5 py-0.5 rounded">{failed}</span>
+          )}
+          <span className="ml-1">{collapsed ? "▲" : "▼"}</span>
+        </div>
+      </div>
+
+      {/* Progress bar for active job */}
+      {currentJob && <Progress value={progress} className="h-1 rounded-none" />}
+
+      {/* Job list */}
+      {!collapsed && (
+        <div className="max-h-64 overflow-y-auto divide-y">
+          {jobs.map((job) => (
+            <div
+              key={job.id}
+              className="flex items-center gap-2 px-3 py-2 text-sm"
+            >
+              <StatusIcon status={job.status} />
+              <div className="flex-1 min-w-0">
+                <div className="font-medium truncate">
+                  {job.type === "delegate" ? "Delegate" : "Vote"}:{" "}
+                  {job.candidateName}
+                </div>
+                <div className="text-xs text-gray-500 truncate">
+                  {job.status === "sent" && job.hash
+                    ? `TX: ${job.hash.slice(0, 20)}...`
+                    : job.message}
+                </div>
+              </div>
+              <div className="text-xs text-gray-400 shrink-0">
+                {job.amount}
+              </div>
+              <div className="flex items-center gap-1 shrink-0">
+                {job.status === "failed" && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-6 px-2 text-xs"
+                    onClick={() => retryJob(job.id)}
+                  >
+                    Retry
+                  </Button>
+                )}
+                {(job.status === "sent" || job.status === "failed") && (
+                  <button
+                    className="text-gray-400 hover:text-gray-600 text-xs px-1"
+                    onClick={() => removeJob(job.id)}
+                  >
+                    ×
+                  </button>
+                )}
+              </div>
+            </div>
+          ))}
+          {sent > 0 && (
+            <div className="px-3 py-1.5">
+              <Button
+                variant="ghost"
+                size="sm"
+                className="text-xs w-full"
+                onClick={clearCompleted}
+              >
+                Clear completed
+              </Button>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Before vs After                                                                                                                                                                
                                                                                                                                                                                  
  ### Before (Current UX)                                                                                                                                                           
                                                                                                                                                                                    
  - **Blocking UI**: Clicking "Vote" locks the entire app with a fullscreen dark overlay + spinner for 30-60+ seconds while the ZK proof builds. You can't do anything else.        
  - **One vote at a time**: To vote on N proposals, you must wait for each ZK proof to complete before starting the next. Total time = N × proof time.                            
  - **No batch voting**: Each vote requires manually selecting a candidate and entering an amount. No way to prepare all votes upfront.
  - **Popup-based feedback**: Success/error shown via SweetAlert popups that interrupt flow and require dismissal.
  - **No progress insight**: Just a raw backend message string + spinner. No sense of how far along the proof is.

  ### After (This PR)

  - **Non-blocking queue**: Submitting a vote adds it to a background queue and immediately returns control to the user. You can queue all your votes in seconds, then let the ZK
  proofs build while you do other things in the app.
  - **Batch JSON import**: "Batch Import" button opens a dialog where you can paste JSON to queue all votes at once. Supports human-readable choice names (`"choice": "Option A"`)
  not just raw addresses. Includes a "Generate Template" button that pre-fills the JSON with all candidates.
  - **Persistent floating queue panel**: A collapsible panel in the bottom-right shows all queued/active/completed/failed jobs across all pages. Includes:
    - Progress bar that estimates stage (witness → nullifier tree → ZK proof → transaction → broadcast)
    - Per-job status with live backend messages
    - Retry button for failed votes
    - Remove/clear controls
  - **Shared architecture**: Single `VoteQueueContext` powers both Vote and Delegate pages — no duplicated logic.

  ### JSON Import Format

  ```json
  [
    { "choice": "Option A", "amount": 5 },
    { "choice": "Option B", "amount": 3 }
  ]

  Or with addresses:

  [
    { "address": "u1abc...", "amount": 5 }
  ]

  Files Changed

  ┌──────────────────────────┬──────────────────────────────────────────────┐
  │           File           │                    Change                    │
  ├──────────────────────────┼──────────────────────────────────────────────┤
  │ src/VoteQueueContext.tsx │ New — shared queue engine (context + hook)   │
  ├──────────────────────────┼──────────────────────────────────────────────┤
  │ src/VoteQueuePanel.tsx   │ New — floating non-blocking status panel     │
  ├──────────────────────────┼──────────────────────────────────────────────┤
  │ src/Vote.tsx             │ Queue integration + JSON batch import dialog │
  ├──────────────────────────┼──────────────────────────────────────────────┤
  │ src/Delegate.tsx         │ Queue integration, removed blocking overlay  │
  ├──────────────────────────┼──────────────────────────────────────────────┤
  │ src/App.tsx              │ Wrapped app in provider, added global panel  │
  └──────────────────────────┴──────────────────────────────────────────────┘
